### PR TITLE
prevent sending context canceled errors to bugsnag

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"context"
+	goerrors "errors"
 	"fmt"
 	golog "log"
 	"path/filepath"
@@ -66,6 +68,15 @@ func InitLog(opts *LogOptions) {
 			config.ProjectPackages = append(config.ProjectPackages, fmt.Sprintf("%s*", projectName))
 		}
 		bugsnag.Configure(config)
+
+		bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+			if goerrors.Is(event.Error, context.Canceled) {
+				return goerrors.New("will not notify about context canceled")
+			}
+
+			// continue notifying as normal
+			return nil
+		})
 
 		hook, err := NewBugsnagHook()
 		if err != nil {


### PR DESCRIPTION
Checking error message before sending to bugsnag to prevent sending context canceled errors as they are not actionable. 
- Making use of [bugsnag.OnBeforeNotify](https://pkg.go.dev/github.com/bugsnag/bugsnag-go@v2.1.1+incompatible#OnBeforeNotify)

## Link to related issue/story
[SC-51490](https://app.shortcut.com/replicated/story/51490/there-are-numerous-non-actionable-context-canceled-errors-in-bugsnag)