### PR TITLE
Filter on embedded error, not bugsnag error

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	perrors "github.com/pkg/errors"
+
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/bugsnag/bugsnag-go/v2/errors"
 )
@@ -20,7 +22,8 @@ func TestFilterEvents(t *testing.T) {
 		// TODO: refactor log, inject param dependency for testability, etc
 		// so we can write tests that InitLog and call Error(), et all
 		{"context canceled, bare", *errors.New(context.Canceled, 1), filteredErr},
-		{"context canceled, wrapped", *errors.New(fmt.Errorf("wrapped %w", context.Canceled), 1), filteredErr},
+		{"context canceled, wrapped in fmt", *errors.New(fmt.Errorf("wrapped %w", context.Canceled), 1), filteredErr},
+		{"context canceled, wrapped in with Wrap()", *errors.New(perrors.Wrap(context.Canceled, "wrapped"), 1), filteredErr},
 		{"context canceled, unwrapped", *errors.New(fmt.Errorf("unwrapped %v", context.Canceled), 1), nil},
 		{"other, bare", *errors.New(goerrors.New("other"), 1), nil},
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -23,7 +23,7 @@ func TestFilterEvents(t *testing.T) {
 		// so we can write tests that InitLog and call Error(), et all
 		{"context canceled, bare", *errors.New(context.Canceled, 1), filteredErr},
 		{"context canceled, wrapped in fmt", *errors.New(fmt.Errorf("wrapped %w", context.Canceled), 1), filteredErr},
-		{"context canceled, wrapped in with Wrap()", *errors.New(perrors.Wrap(context.Canceled, "wrapped"), 1), filteredErr},
+		{"context canceled, wrapped with Wrap()", *errors.New(perrors.Wrap(context.Canceled, "wrapped"), 1), filteredErr},
 		{"context canceled, unwrapped", *errors.New(fmt.Errorf("unwrapped %v", context.Canceled), 1), nil},
 		{"other, bare", *errors.New(goerrors.New("other"), 1), nil},
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"testing"
+
+	"github.com/bugsnag/bugsnag-go/v2"
+	"github.com/bugsnag/bugsnag-go/v2/errors"
+)
+
+func TestFilterEvents(t *testing.T) {
+	tests := []struct {
+		name   string
+		given  errors.Error
+		expect error
+	}{
+		// Cover error construction cases in Error() and Errorf()
+		// TODO: refactor log, inject param dependency for testability, etc
+		// so we can write tests that InitLog and call Error(), et all
+		{"context canceled, bare", *errors.New(context.Canceled, 1), filteredErr},
+		{"context canceled, wrapped", *errors.New(fmt.Errorf("wrapped %w", context.Canceled), 1), filteredErr},
+		{"context canceled, unwrapped", *errors.New(fmt.Errorf("unwrapped %v", context.Canceled), 1), nil},
+		{"other, bare", *errors.New(goerrors.New("other"), 1), nil},
+	}
+	for _, tt := range tests {
+		ev := bugsnag.Event{Error: &tt.given}
+		ret := filterEvents(&ev, nil)
+		if !goerrors.Is(ret, tt.expect) {
+			t.Errorf("filterEvents returned %v, expected %v", ret, tt.expect)
+		}
+	}
+}


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/51490

Fix bug in which we compared the `bugsnag.Event.Error` to the client error we want to filter out (`context.Canceled`).  We need to check the embedded `bugsnag.Event.Error.Err` instead.

Also add a test for event filtering.

Note: this is only a partial fix for SC51490. There will be an additional vandoor PR for to fix calls to `log.Errorf()` and `log.Warnf()` that do not wrap errors correctly (i.e. they use %v instead of %w for chained errors).