### PR TITLE
fix: caller and withfields

### DIFF
--- a/log/caller.go
+++ b/log/caller.go
@@ -1,0 +1,98 @@
+package log
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+
+	// qualified package name, cached at first use
+	ourPackage string
+
+	// Positions in the call stack when tracing to report the calling method
+	minimumCallerDepth int
+
+	// Used for caller information initialisation
+	callerInitOnce sync.Once
+)
+
+const (
+	maximumCallerDepth int = 25
+	knownLogrusFrames  int = 4
+
+	logrusPackage = "github.com/sirupsen/logrus"
+)
+
+func init() {
+	// start at the bottom of the stack before the package-name cache is primed
+	minimumCallerDepth = 1
+}
+
+type CallerHook struct {
+}
+
+func (hook *CallerHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (hook *CallerHook) Fire(entry *logrus.Entry) error {
+	entry.Caller = getCaller()
+	return nil
+}
+
+// getPackageName reduces a fully qualified function name to the package name
+// There really ought to be to be a better way...
+func getPackageName(f string) string {
+	for {
+		lastPeriod := strings.LastIndex(f, ".")
+		lastSlash := strings.LastIndex(f, "/")
+		if lastPeriod > lastSlash {
+			f = f[:lastPeriod]
+		} else {
+			break
+		}
+	}
+
+	return f
+}
+
+// getCaller retrieves the name of the first non-logrus calling function
+func getCaller() *runtime.Frame {
+	// cache this package's fully-qualified name
+	callerInitOnce.Do(func() {
+		pcs := make([]uintptr, maximumCallerDepth)
+		_ = runtime.Callers(0, pcs)
+
+		// dynamic get the package name and the minimum caller depth
+		for i := 0; i < maximumCallerDepth; i++ {
+			funcName := runtime.FuncForPC(pcs[i]).Name()
+			if strings.Contains(funcName, "getCaller") {
+				ourPackage = getPackageName(funcName)
+				break
+			}
+		}
+
+		minimumCallerDepth = knownLogrusFrames
+	})
+
+	// Restrict the lookback frames to avoid runaway lookups
+	pcs := make([]uintptr, maximumCallerDepth)
+	depth := runtime.Callers(minimumCallerDepth, pcs)
+	frames := runtime.CallersFrames(pcs[:depth])
+
+	for f, again := frames.Next(); again; f, again = frames.Next() {
+		pkg := getPackageName(f.Function)
+
+		// If the caller isn't part of this package, we're done
+		if pkg != ourPackage && pkg != logrusPackage {
+			return &f //nolint:scopelint
+		}
+	}
+
+	// if we got here, we failed to find the caller's context
+	return nil
+}

--- a/log/formatters.go
+++ b/log/formatters.go
@@ -3,8 +3,10 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/replicatedcom/saaskit/param"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,7 +18,8 @@ func (cf *ConsoleFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	formattedTime := entry.Time.Format("2006/01/02 15:04:05")
 	formattedLevel := strings.ToUpper(entry.Level.String())
 
-	fmt.Fprintf(result, "%s %s %s %s", formattedLevel, formattedTime, entry.Data["saaskit.file_loc"], entry.Message)
+	caller := fmt.Sprintf("%s:%d", shortPath(entry.Caller.File), entry.Caller.Line)
+	fmt.Fprintf(result, "%s %s %s %s", formattedLevel, formattedTime, caller, entry.Message)
 
 	for k, v := range entry.Data {
 		if strings.HasPrefix(k, "saaskit.") {
@@ -28,4 +31,32 @@ func (cf *ConsoleFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	result.WriteByte('\n')
 	return result.Bytes(), nil
+}
+
+func shortPath(pathIn string) string {
+	projectName := param.Lookup("PROJECT_NAME", "", false)
+	if projectName == "" || !strings.Contains(pathIn, projectName) {
+		return pathIn
+	}
+
+	toks := strings.Split(pathIn, string(filepath.Separator))
+	var resultToks []string
+	for i := len(toks) - 1; i >= 0; i-- {
+		t := toks[i]
+		if t == projectName && i < len(toks)-1 {
+			resultToks = toks[i+1:]
+			break
+		}
+	}
+
+	if resultToks == nil {
+		return pathIn
+	}
+
+	// Truncate absurdly long paths even if they don't match our project name (e.g. godeps).
+	if len(resultToks) > 4 {
+		resultToks = resultToks[len(resultToks)-3:]
+	}
+
+	return strings.Join(resultToks, string(filepath.Separator))
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -31,6 +31,11 @@ func (logger *Logger) AddHook(hook logrus.Hook) {
 	logger.logger.AddHook(hook)
 }
 
+// ReplaceHooks replaces the logger hooks and returns the old ones
+func (logger *Logger) ReplaceHooks(hooks logrus.LevelHooks) logrus.LevelHooks {
+	return logger.logger.ReplaceHooks(hooks)
+}
+
 func (logger *Logger) IsLevelEnabled(level logrus.Level) bool {
 	return logger.logger.IsLevelEnabled(level)
 }


### PR DESCRIPTION
previous to this change, when using withfields the caller is go runtime because the middleware is run as soon as withfields is called.

```
INFO[2023/09/13 06:55:34] /usr/lib/golang/src/runtime/asm_amd64.s:1598 Reconciliation complete, cluster created successfully  cluster_id=40a0183e desired_state=running distribution=openshift operation=reconcile
```

With fix

```
INFO[2023/09/13 19:02:31] cluster-provisioner/pkg/crc/cluster.go:334 Reconciliation complete, cluster created successfully  cluster_id=e9175272 desired_state=running distribution=openshift operation=reconcile
```