### PR TITLE
fix: bugsnag error caller is incorrect with fields

### DIFF
--- a/log/bugsnag_test.go
+++ b/log/bugsnag_test.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	bugsnagerrors "github.com/bugsnag/bugsnag-go/v2/errors"
+	"github.com/replicatedcom/saaskit/param"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBugsnagHook(t *testing.T) {
+	param.Init(nil)
+
+	h := &bugsnagHook{}
+
+	var bugsnagNotifyErr error
+
+	h.BugsnagNotify = func(err error, rawData ...interface{}) error {
+		bugsnagNotifyErr = err
+		return nil
+	}
+
+	log := newLogger()
+	log.SetOutput(io.Discard)
+	log.logger.AddHook(h)
+
+	log.Error("test 1")
+	assert.NotNil(t, bugsnagNotifyErr)
+	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
+	bugsnagErr, _ := bugsnagNotifyErr.(*bugsnagerrors.Error)
+	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
+
+	bugsnagNotifyErr = nil
+
+	log.WithField("test", "test").WithField("test2", "test2").Error("test 2")
+	assert.NotNil(t, bugsnagNotifyErr)
+	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
+	bugsnagErr, _ = bugsnagNotifyErr.(*bugsnagerrors.Error)
+	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
+}

--- a/log/formatters.go
+++ b/log/formatters.go
@@ -18,8 +18,12 @@ func (cf *ConsoleFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	formattedTime := entry.Time.Format("2006/01/02 15:04:05")
 	formattedLevel := strings.ToUpper(entry.Level.String())
 
-	caller := fmt.Sprintf("%s:%d", shortPath(entry.Caller.File), entry.Caller.Line)
-	fmt.Fprintf(result, "%s %s %s %s", formattedLevel, formattedTime, caller, entry.Message)
+	if entry.Caller == nil {
+		fmt.Fprintf(result, "%s %s %s", formattedLevel, formattedTime, entry.Message)
+	} else {
+		caller := fmt.Sprintf("%s:%d", shortPath(entry.Caller.File), entry.Caller.Line)
+		fmt.Fprintf(result, "%s %s %s %s", formattedLevel, formattedTime, caller, entry.Message)
+	}
 
 	for k, v := range entry.Data {
 		if strings.HasPrefix(k, "saaskit.") {


### PR DESCRIPTION
When using WithFields the error file and location is always saaskit hook Fire() function

```
*errors.errorString Failed to send sigint to firecracker process: os: process already finished 
    /home/runner/go/pkg/mod/github.com/replicatedcom/saaskit@v0.0.0-20230913174855-33790436e3c4/log/bugsnag.go:64 (*bugsnagHook).Fire
```
