### PR TITLE
feat(logging): include logrus fields in bugsnag context

### DIFF
--- a/log/bugsnag_test.go
+++ b/log/bugsnag_test.go
@@ -2,10 +2,12 @@
 package log_test
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/bugsnag/bugsnag-go/v2"
 	bugsnagerrors "github.com/bugsnag/bugsnag-go/v2/errors"
 	"github.com/replicatedcom/saaskit/log"
 	"github.com/replicatedcom/saaskit/param"
@@ -13,7 +15,65 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBugsnagHook(t *testing.T) {
+func TestBugsnagHook_ShouldHaveCorrectStackWithGlobalFunctions(t *testing.T) {
+	var bugsnagNotifyErr error
+	setupBugsnagHookTest(t, func(err error, rawData ...interface{}) error {
+		bugsnagNotifyErr = err
+		return nil
+	})
+
+	log.Error("test 1")
+	assert.NotNil(t, bugsnagNotifyErr)
+	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
+	bugsnagErr, _ := bugsnagNotifyErr.(*bugsnagerrors.Error)
+	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
+}
+
+func TestBugsnagHook_ShouldHaveCorrectStackWithFields(t *testing.T) {
+	var bugsnagNotifyErr error
+	setupBugsnagHookTest(t, func(err error, rawData ...interface{}) error {
+		bugsnagNotifyErr = err
+		return nil
+	})
+
+	log.WithField("test", "test").WithField("test2", "test2").Error("test 2")
+	assert.NotNil(t, bugsnagNotifyErr)
+	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
+	bugsnagErr, _ := bugsnagNotifyErr.(*bugsnagerrors.Error)
+	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
+}
+
+func TestBugsnagHook_ShouldHaveCorrectErrorWithError(t *testing.T) {
+	var bugsnagNotifyErr error
+	setupBugsnagHookTest(t, func(err error, rawData ...interface{}) error {
+		bugsnagNotifyErr = err
+		return nil
+	})
+
+	log.WithField("blah", "blahval").WithError(errors.New("test error")).Error("this is the message")
+	assert.NotNil(t, bugsnagNotifyErr)
+	assert.Equal(t, bugsnagNotifyErr.Error(), "test error")
+}
+
+func TestBugsnagHook_ShouldIncludeMetadata(t *testing.T) {
+	var metadata bugsnag.MetaData
+	setupBugsnagHookTest(t, func(err error, rawData ...interface{}) error {
+		for _, raw := range rawData {
+			if m, ok := raw.(bugsnag.MetaData); ok {
+				metadata = m
+			}
+		}
+		return nil
+	})
+
+	log.WithField("blah", "blahval").WithError(errors.New("test error")).Error("this is the message")
+	assert.Equal(t, metadata[log.BugsnagMetadataTabKey], map[string]interface{}{
+		log.BugsnagEntryMessageKey: "this is the message",
+		"blah":                     "blahval",
+	})
+}
+
+func setupBugsnagHookTest(t *testing.T, hook log.BugsnagNotifyFunc) log.Logger {
 	param.Init(nil)
 	log.InitLog(&log.LogOptions{
 		LogLevel:   "debug",
@@ -23,28 +83,11 @@ func TestBugsnagHook(t *testing.T) {
 	h, err := log.NewBugsnagHook()
 	require.NoError(t, err)
 
-	var bugsnagNotifyErr error
-
-	h.BugsnagNotify = func(err error, rawData ...interface{}) error {
-		bugsnagNotifyErr = err
-		return nil
-	}
+	h.BugsnagNotify = hook
 
 	log := log.Log
 	log.SetOutput(io.Discard)
 	log.AddHook(h)
 
-	log.Error("test 1")
-	assert.NotNil(t, bugsnagNotifyErr)
-	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
-	bugsnagErr, _ := bugsnagNotifyErr.(*bugsnagerrors.Error)
-	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
-
-	bugsnagNotifyErr = nil
-
-	log.WithField("test", "test").WithField("test2", "test2").Error("test 2")
-	assert.NotNil(t, bugsnagNotifyErr)
-	assert.IsType(t, &bugsnagerrors.Error{}, bugsnagNotifyErr)
-	bugsnagErr, _ = bugsnagNotifyErr.(*bugsnagerrors.Error)
-	assert.Contains(t, strings.Split(string(bugsnagErr.Stack()), "/n")[0], "testing.go:")
+	return log
 }


### PR DESCRIPTION
Adds metadata from logrus fields to the bugsnag error for aid in debugging.

![Screenshot 2023-10-16 at 11 55 03 AM](https://github.com/replicatedcom/saaskit/assets/371319/b527b86c-78e3-4004-a9e1-fa50440e487e)
