### PR TITLE
sc-99946: associating logs to traces

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -35,7 +35,8 @@ func InitLog(opts *LogOptions) {
 
 	Log.SetFormatter(&ConsoleFormatter{})
 
-	Log.logger.AddHook(&CallerHook{})
+	Log.AddHook(&CallerHook{})
+	Log.AddHook(&dd_logrus.DDContextLogHook{}) // This associates TraceID to logs
 
 	if opts == nil {
 		return


### PR DESCRIPTION
# Description
Associating logs to traces in DataDog.
removing redundant logging function