### PR TITLE
feature(formatters): add JSONFormatter

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -12,14 +12,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	Log Logger
-)
+var Log Logger
 
 type LogOptions struct {
 	LogLevel   string
 	BugsnagKey string
 	AppVersion string
+
+	// UseJSONFormatter will use JSONFormatter, default is ConsoleFormatter.
+	UseJSONFormatter bool
 }
 
 func InitLog(opts *LogOptions) {
@@ -33,12 +34,16 @@ func InitLog(opts *LogOptions) {
 		}
 	}
 
-	Log.SetFormatter(&ConsoleFormatter{})
-
 	Log.logger.AddHook(&CallerHook{})
 
 	if opts == nil {
 		return
+	}
+
+	if opts.UseJSONFormatter {
+		Log.SetFormatter(&JSONFormatter{})
+	} else {
+		Log.SetFormatter(&ConsoleFormatter{})
 	}
 
 	if opts.LogLevel != "" {
@@ -74,6 +79,7 @@ func InitLog(opts *LogOptions) {
 func WithField(key string, value interface{}) *logrus.Entry {
 	return Log.WithField(key, value)
 }
+
 func WithFields(fields logrus.Fields) *logrus.Entry {
 	return Log.WithFields(fields)
 }
@@ -81,6 +87,7 @@ func WithFields(fields logrus.Fields) *logrus.Entry {
 func Debug(args ...interface{}) {
 	Log.Debug(args...)
 }
+
 func Debugf(format string, args ...interface{}) {
 	Log.Debugf(format, args...)
 }
@@ -88,6 +95,7 @@ func Debugf(format string, args ...interface{}) {
 func Info(args ...interface{}) {
 	Log.Info(args...)
 }
+
 func Infof(format string, args ...interface{}) {
 	Log.Infof(format, args...)
 }
@@ -95,12 +103,15 @@ func Infof(format string, args ...interface{}) {
 func Warning(args ...interface{}) {
 	Log.WithFields(getSaaskitError(args, 1)).Warning(args...)
 }
+
 func Warningf(format string, args ...interface{}) {
 	Log.WithFields(getSaaskitErrorf(format, args, 1)).Warningf(format, args...)
 }
+
 func Warn(args ...interface{}) {
 	Log.WithFields(getSaaskitError(args, 1)).Warning(args...)
 }
+
 func Warnf(format string, args ...interface{}) {
 	Log.WithFields(getSaaskitErrorf(format, args, 1)).Warningf(format, args...)
 }
@@ -108,6 +119,7 @@ func Warnf(format string, args ...interface{}) {
 func Error(args ...interface{}) {
 	Log.WithFields(getSaaskitError(args, 1)).Error(args...)
 }
+
 func Errorf(format string, args ...interface{}) {
 	// NOTE: this must support the %w wrap verb since vandoor uses it
 	err := fmt.Errorf(format, args...)
@@ -117,6 +129,7 @@ func Errorf(format string, args ...interface{}) {
 func Fatal(args ...interface{}) {
 	Log.WithFields(getSaaskitError(args, 1)).Fatal(args...)
 }
+
 func Fatalf(format string, args ...interface{}) {
 	Log.WithFields(getSaaskitErrorf(format, args, 1)).Fatalf(format, args...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -96,7 +96,7 @@ func TestPrefixFieldClashes(t *testing.T) {
 	assert.Contains(t, out.String(), `"fields.timestamp":"test"`)
 	assert.Contains(t, out.String(), `"fields.caller":"test"`)
 	assert.Contains(t, out.String(), `"level":"info"`)
-	assert.Contains(t, out.String(), `"message":"super awesome tst"`)
+	assert.Contains(t, out.String(), `"message":"super awesome test"`)
 }
 
 func TestSaaskitError(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -43,23 +43,60 @@ func TestFilterEvents(t *testing.T) {
 
 func TestCallerHook(t *testing.T) {
 	param.Init(nil)
-
-	h := &CallerHook{}
+	log := newLogger()
+	log.AddHook(&CallerHook{})
 
 	out := bytes.NewBuffer(nil)
-	log := newLogger()
-	log.SetOutput(out)
-	log.logger.AddHook(h)
-	log.SetFormatter(&ConsoleFormatter{})
-
-	log.Error("test 1")
-	assert.Contains(t, out.String(), "testing.go:")
-
-	out = bytes.NewBuffer(nil)
 	log.SetOutput(out)
 
-	log.WithField("test", "test").WithField("test2", "test2").Error("test 2")
-	assert.Contains(t, out.String(), "testing.go:")
+	validateFunc := func(formatter logrus.Formatter) {
+		if _, ok := formatter.(*JSONFormatter); ok {
+			assert.Contains(t, out.String(), "caller", "testing.go:")
+		} else {
+			assert.Contains(t, out.String(), "testing.go:")
+		}
+
+		out.Reset()
+	}
+
+	for _, formatter := range []logrus.Formatter{
+		&ConsoleFormatter{}, &JSONFormatter{},
+	} {
+		t.Run(fmt.Sprintf("%T", formatter), func(t *testing.T) {
+			log.SetFormatter(formatter)
+
+			log.Error("test 1")
+			validateFunc(formatter)
+
+			log.WithField("test", "test").WithField("test2", "test2").Info("test 2")
+			validateFunc(formatter)
+		})
+	}
+}
+
+func TestPrefixFieldClashes(t *testing.T) {
+	param.Init(nil)
+	Log = newLogger()
+
+	out := bytes.NewBuffer(nil)
+	Log.SetOutput(out)
+	Log.SetFormatter(&JSONFormatter{})
+
+	Log.AddHook(&CallerHook{})
+
+	Log.WithFields(logrus.Fields{
+		"level":     "test",
+		"message":   "test",
+		"timestamp": "test",
+		"caller":    "test",
+	}).Info("super awesome test")
+
+	assert.Contains(t, out.String(), `"fields.level":"test"`)
+	assert.Contains(t, out.String(), `"fields.message":"test"`)
+	assert.Contains(t, out.String(), `"fields.timestamp":"test"`)
+	assert.Contains(t, out.String(), `"fields.caller":"test"`)
+	assert.Contains(t, out.String(), `"level":"info"`)
+	assert.Contains(t, out.String(), `"message":"super awesome tst"`)
 }
 
 func TestSaaskitError(t *testing.T) {
@@ -85,25 +122,30 @@ func TestSaaskitError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out := bytes.NewBuffer(nil)
-			Log.SetOutput(out)
+		for _, formatter := range []logrus.Formatter{
+			&ConsoleFormatter{}, &JSONFormatter{},
+		} {
+			t.Run(fmt.Sprintf("%s %T", tt.name, formatter), func(t *testing.T) {
+				out := bytes.NewBuffer(nil)
+				Log.SetOutput(out)
+				Log.SetFormatter(formatter)
 
-			h := &hook{}
-			Log.AddHook(h)
+				h := &hook{}
+				Log.AddHook(h)
 
-			Error(tt.args...)
+				Error(tt.args...)
 
-			require.Len(t, h.entries, 1)
-			require.Contains(t, h.entries[0].Data, "saaskit.error")
-			if bugsnagErr, ok := h.entries[0].Data["saaskit.error"].(*errors.Error); ok {
-				assert.IsType(t, tt.wantErrType, bugsnagErr.Err)
-				firstLine := strings.Split(string(bugsnagErr.Stack()), "\n")[0]
-				assert.Contains(t, firstLine, "log_test.go:")
-			} else {
-				assert.IsType(t, tt.wantErrType, h.entries[0].Data["saaskit.error"])
-			}
-		})
+				require.Len(t, h.entries, 1)
+				require.Contains(t, h.entries[0].Data, "saaskit.error")
+				if bugsnagErr, ok := h.entries[0].Data["saaskit.error"].(*errors.Error); ok {
+					assert.IsType(t, tt.wantErrType, bugsnagErr.Err)
+					firstLine := strings.Split(string(bugsnagErr.Stack()), "\n")[0]
+					assert.Contains(t, firstLine, "log_test.go:")
+				} else {
+					assert.IsType(t, tt.wantErrType, h.entries[0].Data["saaskit.error"])
+				}
+			})
+		}
 	}
 }
 
@@ -127,25 +169,30 @@ func TestSaaskitErrorf(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out := bytes.NewBuffer(nil)
-			Log.SetOutput(out)
+		for _, formatter := range []logrus.Formatter{
+			&ConsoleFormatter{}, &JSONFormatter{},
+		} {
+			t.Run(fmt.Sprintf("%s %T", tt.name, formatter), func(t *testing.T) {
+				out := bytes.NewBuffer(nil)
+				Log.SetOutput(out)
+				Log.SetFormatter(formatter)
 
-			h := &hook{}
-			Log.AddHook(h)
+				h := &hook{}
+				Log.AddHook(h)
 
-			Errorf(tt.format, tt.args...)
+				Errorf(tt.format, tt.args...)
 
-			require.Len(t, h.entries, 1)
-			require.Contains(t, h.entries[0].Data, "saaskit.error")
-			if bugsnagErr, ok := h.entries[0].Data["saaskit.error"].(*errors.Error); ok {
-				assert.IsType(t, tt.wantErrType, bugsnagErr.Err)
-				firstLine := strings.Split(string(bugsnagErr.Stack()), "\n")[0]
-				assert.Contains(t, firstLine, "log_test.go:")
-			} else {
-				assert.IsType(t, tt.wantErrType, h.entries[0].Data["saaskit.error"])
-			}
-		})
+				require.Len(t, h.entries, 1)
+				require.Contains(t, h.entries[0].Data, "saaskit.error")
+				if bugsnagErr, ok := h.entries[0].Data["saaskit.error"].(*errors.Error); ok {
+					assert.IsType(t, tt.wantErrType, bugsnagErr.Err)
+					firstLine := strings.Split(string(bugsnagErr.Stack()), "\n")[0]
+					assert.Contains(t, firstLine, "log_test.go:")
+				} else {
+					assert.IsType(t, tt.wantErrType, h.entries[0].Data["saaskit.error"])
+				}
+			})
+		}
 	}
 }
 
@@ -170,8 +217,7 @@ func (h *hook) Levels() []logrus.Level {
 
 var _ error = myError{}
 
-type myError struct {
-}
+type myError struct{}
 
 func (e myError) Error() string {
 	return "my error"


### PR DESCRIPTION
This adds a `JSONFormatter` based on the `logrus.JSONFormatter` implementation.  It updates the existing tests where we test the `ConsoleFormatter` to test both formatters and adds a new test to test prefixing of fields.

The intent for this is to use this formatter for logging in vandoor, specifically in https://github.com/replicatedhq/vandoor/pull/6859