### PR TITLE
feature(logger): add support for creating new logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -24,32 +24,37 @@ type LogOptions struct {
 }
 
 func InitLog(opts *LogOptions) {
-	Log = newLogger()
-	Log.SetLevel(logrus.DebugLevel) // default
+	Log = New(opts)
+}
+
+// New returns a new local Logger.
+func New(opts *LogOptions) Logger {
+	nl := newLogger()
+	nl.SetLevel(logrus.DebugLevel) // default
 	logLevel := param.Lookup("LOG_LEVEL", "/replicated/log_level", false)
 	if logLevel != "" {
 		lvl, err := logrus.ParseLevel(logLevel)
 		if err == nil {
-			Log.SetLevel(lvl)
+			nl.SetLevel(lvl)
 		}
 	}
 
-	Log.logger.AddHook(&CallerHook{})
+	nl.logger.AddHook(&CallerHook{})
 
 	if opts == nil {
-		return
+		return nl
 	}
 
 	if opts.UseJSONFormatter {
-		Log.SetFormatter(&JSONFormatter{})
+		nl.SetFormatter(&JSONFormatter{})
 	} else {
-		Log.SetFormatter(&ConsoleFormatter{})
+		nl.SetFormatter(&ConsoleFormatter{})
 	}
 
 	if opts.LogLevel != "" {
 		lvl, err := logrus.ParseLevel(opts.LogLevel)
 		if err == nil {
-			Log.SetLevel(lvl)
+			nl.SetLevel(lvl)
 		}
 	}
 
@@ -72,8 +77,10 @@ func InitLog(opts *LogOptions) {
 			golog.Fatal(err)
 		}
 
-		Log.AddHook(hook)
+		nl.AddHook(hook)
 	}
+
+	return nl
 }
 
 func WithField(key string, value interface{}) *logrus.Entry {


### PR DESCRIPTION
`InitLog` has been renamed to `New` and `InitLog` now calls `New`, this allows us to get a localized new logger outside of the default `Logger`.

I tested this against PR: https://github.com/replicatedhq/vandoor/pull/6859

The `eventLog` logger instantiated with `log.New` fires in `JSONFormatter` but the other logger fires everything else:

```
{"caller":"cluster/event_log.go:49","cluster_guid":"7e95da15","cluster_name":"serene_wright","distribution":"fake","instance_types":["r1.small"],"level":"info","message":"cluster create resulted in error status","node_count":1,"node_groups":1,"status":"error","team_id":"2rMLsxkHYFV27t5oCfSyYOfVtNH","team_name":"Mango, Inc.","team_url":"https://admin.replbiz.com/teams/2rMLsxkHYFV27t5oCfSyYOfVtNH","timestamp":"2025/02/06 04:47:16","ttl":"1h","version":"1.37"}
[GIN] 2025/02/06 - 04:47:16 | 200 |   98.238281ms | 10.0.6.135 |   PUT     /internal/v3/reliability_matrix/cluster_provisioner
DEBUG 2025/02/06 04:47:16 /go/pkg/mod/github.com/replicatedcom/saaskit@v0.0.0-20250206043459-1b1d5ef61e42/log/gin.go:45 [GIN] 200 |   98.04784ms | 10.0.6.135 | PUT     /internal/v3/reliability_matrix/cluster_provisioner
ERROR 2025/02/06 04:47:16 cluster/cluster.go:2025 Failed to send slack notification for cluster 7e95da15: failed to update cluster event slack message: channel_not_found
[GIN] 2025/02/06 - 04:47:16 | 200 |   20.863855ms | 10.0.6.135 |   PUT     /internal/v3/reliability_matrix/cluster_provisioner_versions
```